### PR TITLE
Default CSS file for imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "9.1.0",
     "description": "Blazing fast and lightweight autocomplete library without dependencies. 1KB gzipped.",
     "main": "autocomplete.js",
+    "style": "autocomplete.css",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1",
         "build:js": "rollup -c",


### PR DESCRIPTION
Allows postcss-import to know which default file to use (https://jaketrent.com/post/package-json-style-attribute/)