### PR TITLE
fix: change `.innerHTML` to `.textContent` for CSP compliance

### DIFF
--- a/autocomplete.ts
+++ b/autocomplete.ts
@@ -319,7 +319,7 @@ export default function autocomplete<T extends AutocompleteItem>(settings: Autoc
      */
     function update() {
 
-        container.innerHTML = '';
+        container.textContent = '';
         input.setAttribute('aria-activedescendant', '');
 
         // function for rendering autocomplete suggestions


### PR DESCRIPTION
I think we should use `textContent` to reduce CSP (Content  Security Policy) requirements. If we add CSP `require-trusted-types-for 'script'`, then it blocks `innerHTML` unless it's `TrustedHTML` (as can be seen in this [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/require-trusted-types-for) article), however in the case of this lib's usage, we can simply replace the `innerHTML` with `textContent` which has the exact same effect and is CSP compliant

For reference, you can see this [PR](https://github.com/vitejs/vite/pull/10801) on the Vite project, they've done the exact same code change.